### PR TITLE
Try using std lib to manage logger formatting.

### DIFF
--- a/gb-emu.vcxproj
+++ b/gb-emu.vcxproj
@@ -75,7 +75,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WINDOWS; _CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <PrecompiledHeaderFile>pch.hpp</PrecompiledHeaderFile>
     </ClCompile>
@@ -94,7 +94,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WINDOWS; _CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <PrecompiledHeaderFile>pch.hpp</PrecompiledHeaderFile>
     </ClCompile>

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -7,7 +7,7 @@ void Logger::Log(const std::string message, ...)
     std::unique_ptr<char[]> buf(new char[size]);
     va_list argPointer;
     va_start(argPointer, message);
-    vsnprintf_s(&buf.get()[0], size, size, message.c_str(), argPointer);
+    vsnprintf(&buf.get()[0], size, message.c_str(), argPointer);
     va_end(argPointer);
 
     std::cout << buf.get() << std::endl;
@@ -19,7 +19,7 @@ void Logger::LogError(const std::string message, ...)
     std::unique_ptr<char[]> buf(new char[size]);
     va_list argPointer;
     va_start(argPointer, message);
-    vsnprintf_s(&buf.get()[0], size, size, message.c_str(), argPointer);
+    vsnprintf(&buf.get()[0], size, message.c_str(), argPointer);
     va_end(argPointer);
 
     std::cerr << buf.get() << std::endl;

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -3,24 +3,28 @@
 
 void Logger::Log(const std::string message, ...)
 {
-    size_t size = message.length() * 2;
-    std::unique_ptr<char[]> buf(new char[size]);
     va_list argPointer;
     va_start(argPointer, message);
-    vsnprintf(&buf.get()[0], size, message.c_str(), argPointer);
-    va_end(argPointer);
 
+    // Get the size required so we can allocate the correct sapce
+    size_t size = std::vsnprintf(nullptr, 0, message.c_str(), argPointer);
+    std::unique_ptr<char[]> buf(new char[size]);
+    std::vsnprintf(&buf.get()[0], size, message.c_str(), argPointer);
+
+    va_end(argPointer);
     std::cout << buf.get() << std::endl;
 }
 
 void Logger::LogError(const std::string message, ...)
 {
-    size_t size = message.length() * 2;
-    std::unique_ptr<char[]> buf(new char[size]);
     va_list argPointer;
     va_start(argPointer, message);
-    vsnprintf(&buf.get()[0], size, message.c_str(), argPointer);
-    va_end(argPointer);
 
+    // Get the size required so we can allocate the correct sapce
+    size_t size = std::vsnprintf(nullptr, 0, message.c_str(), argPointer);
+    std::unique_ptr<char[]> buf(new char[size]);
+    std::vsnprintf(&buf.get()[0], size, message.c_str(), argPointer);
+
+    va_end(argPointer);
     std::cerr << buf.get() << std::endl;
 }

--- a/src/PCH.hpp
+++ b/src/PCH.hpp
@@ -3,20 +3,15 @@
 #include <string>
 #include <iostream>
 
-#include <stdarg.h>
+#include <cstdarg>
 #include <memory>
 
 #if WINDOWS
     #include <SDL.h>
     #include <SDL_mixer.h>
-
-    #define vsnprintf _vsnprintf
 #else
     #include "SDL2/SDL.h"
     #include "SDL2_mixer/SDL_mixer.h"
-
-    // TODO: Doosk to add the correct #define macro here to map to OSX's printf if necessary
-    //#define vsnprintf _vsnprintf???
 #endif
 
 #include "Logger.hpp"

--- a/src/PCH.hpp
+++ b/src/PCH.hpp
@@ -9,9 +9,14 @@
 #if WINDOWS
     #include <SDL.h>
     #include <SDL_mixer.h>
+
+    #define vsnprintf _vsnprintf
 #else
     #include "SDL2/SDL.h"
     #include "SDL2_mixer/SDL_mixer.h"
+
+    // TODO: Doosk to add the correct #define macro here to map to OSX's printf if necessary
+    //#define vsnprintf _vsnprintf???
 #endif
 
 #include "Logger.hpp"


### PR DESCRIPTION
Change stdlib to cstdlib
Disable warnings on windows build about unsafe function.
Calculate the correct size necessary before buffer allocation.