### PR TITLE
Refactor PC incrementing

### DIFF
--- a/gb-emu-lib/CPU.hpp
+++ b/gb-emu-lib/CPU.hpp
@@ -62,6 +62,8 @@ private:
     void PushUShortToSP(ushort val);
     ushort PopUShort();
     byte PopByte();
+    byte ReadBytePC();
+    ushort ReadUShortPC();
 
     void HALT();
 

--- a/gb-emu-lib/CPU.hpp
+++ b/gb-emu-lib/CPU.hpp
@@ -84,8 +84,8 @@ private:
     void POPBC();           // 0xC1
     void PUSHBC();          // 0xC5
     void CALLnn();          // 0xCD
-    void LD_0xFF00C_A();    // 0xE0
-    void LD_0xFF00n_A();    // 0xE2
+    void LD_0xFF00n_A();    // 0xE0
+    void LD_0xFF00C_A();    // 0xE2
 
     // OpCode 0xCB functions
     void RLC();             // 0x11

--- a/gb-emu/Main.cpp
+++ b/gb-emu/Main.cpp
@@ -151,7 +151,7 @@ int main(int argc, char** argv)
                 // Sleep for (16ms - elapsed frame time)
                 SDL_Delay(delay);
             }
-            else
+            else if (frameElapsedTime > TimePerFrame)
             {
                 Logger::Log("Frame time was too long: %dms  (Expect less than %dms)", frameElapsedTime, TimePerFrame);
             }


### PR DESCRIPTION
The m_PC += 1; and stuff was everywhere, and easy to mess up. I refactored this logic into two methods on the CPU.

CPU::ReadBytePC() and CPU::ReadUShortPC()

You call these and it pulls the correct value out, and increments the PC for you.  When you need to read "n", just call ReadBytePC()  When you need to read "nn" just call ReadUShortPC().